### PR TITLE
remove duplicate #general tag

### DIFF
--- a/tags.njk
+++ b/tags.njk
@@ -10,7 +10,7 @@ layout: layout.njk
 <h1 class="title">#{{ tag }}</h1>
 
 <p class="no-share">
-  <a class="tag" href="/tags/featured">#featured</a> <a class="tag" href="/tags/general">#general</a> <a class="tag" href="/tags/nodejs">#nodejs</a> <a class="tag" href="/tags/general">#general</a> <a class="tag" href="/tags/javascript">#javascript</a> <a class="tag" href="/tags/tutorial">#tutorial</a> <a class="tag" href="/tags/crypto">#crypto</a>
+  <a class="tag" href="/tags/featured">#featured</a> <a class="tag" href="/tags/general">#general</a> <a class="tag" href="/tags/nodejs">#nodejs</a> <a class="tag" href="/tags/javascript">#javascript</a> <a class="tag" href="/tags/tutorial">#tutorial</a> <a class="tag" href="/tags/crypto">#crypto</a>
 </p>
 
 <ol reversed>


### PR DESCRIPTION
Hi,
if you go on https://christianfei.com/tags/featured/ the `#general` tag appears twice (introduced in https://github.com/christian-fei/christian-fei.github.io/commit/cb63824ff91ecf4298f83b34094e64b6b8458bd8).

BTW: the patch is a bit dirty (has been done through the GitHub web editor) but it should be OK. (Interestingly I've completely deleted `<a class="tag" href="/tags/general">#general</a>` but git show it as if I removed the tail of the `#general` <a> tag and the head of `#javascript` <a> tag...also I've never touched the last `<ol>` :thinking:  !)